### PR TITLE
Fix components bullet on single line

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Abre el navegador en la URL mostrada en la terminal para ver la aplicación.
 
 ## Estructura del proyecto
 
-- `src/components`: componentes reutilizables como `PropertyCard`, `PropertyList`, `PropertyForm` y `Layout`.
+- `src/components`: componentes reutilizables (`PropertyCard`, `PropertyList`, `PropertyForm` y `Layout`).
 - `src/App.jsx`: punto de entrada que usa `Layout`.
 
 ## Construcción para producción


### PR DESCRIPTION
## Summary
- ensure README bullet for reusable components fits on one line

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68586045c54083219418c084b204dec5